### PR TITLE
Improve SB CLI performance for delete + update calls

### DIFF
--- a/sbcli/servicecalls.go
+++ b/sbcli/servicecalls.go
@@ -304,20 +304,8 @@ func DeleteService(cmd *Commandline) {
 
 	sb := NewSBClient()
 
-	instances, err := sb.Instances()
+	_, err := sb.Instance(cmd.Options[0])
 	CheckErr(err)
-
-	found := false
-	for _, instance := range instances.Resources {
-		if instance.GUIDAtTenant == cmd.Options[0] {
-			found = true
-			break
-		}
-	}
-
-	if !found {
-		CheckErr(errors.New("Service not found!"))
-	}
 
 	if !cmd.Force {
 		reader := bufio.NewReader(os.Stdin)
@@ -351,20 +339,8 @@ func UpdateService(cmd *Commandline) {
 
 	sb := NewSBClient()
 
-	instances, err := sb.Instances()
+	_, err := sb.Instance(cmd.Options[0])
 	CheckErr(err)
-
-	found := false
-	for _, instance := range instances.Resources {
-		if instance.GUIDAtTenant == cmd.Options[0] {
-			found = true
-			break
-		}
-	}
-
-	if !found {
-		CheckErr(errors.New("Service not found!"))
-	}
 
 	data, err := getServiceIDPlanID(cmd.Options[0])
 	CheckErr(err)


### PR DESCRIPTION
Instead of calling all instances to check if the instance with the given guid exists we can simply call sb.Instance which will error out if the instance does not exist.

This not only makes it way faster but it also reduces the load on the broker + pg because it does not need to provide all instances all the time. 